### PR TITLE
feat: add k8s policy with a bool attribute

### DIFF
--- a/aws-sso/k8s_access.tf
+++ b/aws-sso/k8s_access.tf
@@ -1,0 +1,15 @@
+data "aws_iam_policy_document" "eks_access" {
+    statement {
+    sid = "eksAccessPolicy"
+
+    actions = [
+        "eks:DescribeCluster",
+        "eks:ListClusters"
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+ 
+}

--- a/aws-sso/tags.tf
+++ b/aws-sso/tags.tf
@@ -5,7 +5,6 @@ variable "defaultTags" {
     owner       = "something"
     cost-centre = "something"
     contact     = "something"
-    tf_Managed  = "true"
-    repo        = "something"
+    tf_managed  = "true"
   }
 }

--- a/aws-sso/variable.tf
+++ b/aws-sso/variable.tf
@@ -4,6 +4,7 @@ variable "roles" {
   default = {
     session_duration = "PT2H"
     relay_state      = null
+    k8s_access       = false
   }
 }
 


### PR DESCRIPTION
** adding role attribute `k8s_access`
** When true, will combine the `eks_access` policy with the existing inline_policy 
** Moving repo tag to downstream